### PR TITLE
grub: Add option for graphics improvement

### DIFF
--- a/layers/meta-resin-up-board/recipes-bsp/grub/files/grub.cfg_internal-dev
+++ b/layers/meta-resin-up-board/recipes-bsp/grub/files/grub.cfg_internal-dev
@@ -4,5 +4,5 @@ default=boot
 timeout=3
 
 menuentry 'boot'{
-linux /vmlinuz root=LABEL=resin-rootA rootwait processor.max_cstate=1
+linux /vmlinuz root=LABEL=resin-rootA rootwait processor.max_cstate=1 i915.enable_rc6=0
 }

--- a/layers/meta-resin-up-board/recipes-bsp/grub/files/grub.cfg_internal-prod
+++ b/layers/meta-resin-up-board/recipes-bsp/grub/files/grub.cfg_internal-prod
@@ -4,5 +4,5 @@ default=boot
 timeout=0
 
 menuentry 'boot'{
-linux /vmlinuz root=LABEL=resin-rootA rootwait quiet loglevel=0 splash udev.log-priority=3 vt.global_cursor_default=0 processor.max_cstate=1
+linux /vmlinuz root=LABEL=resin-rootA rootwait quiet loglevel=0 splash udev.log-priority=3 vt.global_cursor_default=0 processor.max_cstate=1 i915.enable_rc6=0
 }


### PR DESCRIPTION
This patch adds the "i915.enable_rc6=0" option in grub
to reduce graphics glitches/flickering

Changelog-entry: grub: Add option for graphics improvement
Signed-off-by: Sebastian Panceac <sebastian@balena.io>