### PR TITLE
linux-yocto_%.bbappend: Revert "random: fix crng_ready() test" patch

### DIFF
--- a/layers/meta-balena-up-board/recipes-kernel/linux/files/0001-Revert-random-fix-crng_ready-test.patch
+++ b/layers/meta-balena-up-board/recipes-kernel/linux/files/0001-Revert-random-fix-crng_ready-test.patch
@@ -1,0 +1,69 @@
+From 2f19b9613a76956437d7e3ad1bcfa58fc8550b71 Mon Sep 17 00:00:00 2001
+From: Florin Sarbu <florin@resin.io>
+Date: Mon, 8 Oct 2018 20:21:21 +0200
+Subject: [PATCH] Revert "random: fix crng_ready() test"
+
+This reverts commit 6e513bc20ca63f594632eca4e1968791240b8f18
+from our kernel tree.
+
+We revert this because with that patch, balena gets started
+with a delay because of the lack of entropy.
+
+Upstream-Status: Inappropriate [configuration]
+Signed-off-by: Florin Sarbu <florin@resin.io>
+---
+ drivers/char/random.c | 10 +++++-----
+ 1 file changed, 5 insertions(+), 5 deletions(-)
+
+diff --git a/drivers/char/random.c b/drivers/char/random.c
+index ddc493d..f708ff1 100644
+--- a/drivers/char/random.c
++++ b/drivers/char/random.c
+@@ -428,7 +428,7 @@ struct crng_state primary_crng = {
+  * its value (from 0->1->2).
+  */
+ static int crng_init = 0;
+-#define crng_ready() (likely(crng_init > 1))
++#define crng_ready() (likely(crng_init > 0))
+ static int crng_init_cnt = 0;
+ static unsigned long crng_global_init_time = 0;
+ #define CRNG_INIT_CNT_THRESH (2*CHACHA20_KEY_SIZE)
+@@ -842,7 +842,7 @@ static int crng_fast_load(const char *cp, size_t len)
+ 
+ 	if (!spin_trylock_irqsave(&primary_crng.lock, flags))
+ 		return 0;
+-	if (crng_init != 0) {
++	if (crng_ready()) {
+ 		spin_unlock_irqrestore(&primary_crng.lock, flags);
+ 		return 0;
+ 	}
+@@ -962,7 +962,7 @@ static void _extract_crng(struct crng_state *crng,
+ {
+ 	unsigned long v, flags;
+ 
+-	if (crng_ready() &&
++	if (crng_init > 1 &&
+ 	    (time_after(crng_global_init_time, crng->init_time) ||
+ 	     time_after(jiffies, crng->init_time + CRNG_RESEED_INTERVAL)))
+ 		crng_reseed(crng, crng == &primary_crng ? &input_pool : NULL);
+@@ -1247,7 +1247,7 @@ void add_interrupt_randomness(int irq, int irq_flags)
+ 	fast_mix(fast_pool);
+ 	add_interrupt_bench(cycles);
+ 
+-	if (unlikely(crng_init == 0)) {
++	if (!crng_ready()) {
+ 		if ((fast_pool->count >= 64) &&
+ 		    crng_fast_load((char *) fast_pool->pool,
+ 				   sizeof(fast_pool->pool))) {
+@@ -2316,7 +2316,7 @@ void add_hwgenerator_randomness(const char *buffer, size_t count,
+ {
+ 	struct entropy_store *poolp = &input_pool;
+ 
+-	if (unlikely(crng_init == 0)) {
++	if (!crng_ready()) {
+ 		crng_fast_load(buffer, count);
+ 		return;
+ 	}
+-- 
+2.7.4
+

--- a/layers/meta-balena-up-board/recipes-kernel/linux/linux-yocto_%.bbappend
+++ b/layers/meta-balena-up-board/recipes-kernel/linux/linux-yocto_%.bbappend
@@ -1,5 +1,9 @@
 inherit kernel-resin
 
+FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
+
+SRC_URI += "file://0001-Revert-random-fix-crng_ready-test.patch"
+
 # HDMI audio support requested by customer
 RESIN_CONFIGS_append = " hdmi_sound"
 RESIN_CONFIGS[hdmi_sound] = " \


### PR DESCRIPTION
The introduction of this patch caused balena to start with a delay
because not enough entropy is gathered by the time balena starts.

Changelog-entry: Revert "random: fix crng_ready() test" to fix balena delay start issue
Signed-off-by: Florin Sarbu <florin@balena.io>