### PR TITLE
up-board.coffee: Set private to false for the public device types

### DIFF
--- a/up-board.coffee
+++ b/up-board.coffee
@@ -20,6 +20,7 @@ module.exports =
 	name: 'UP Board'
 	arch: 'amd64'
 	state: 'released'
+	private: false
 
 	stateInstructions:
 		postProvisioning: postProvisioningInstructions


### PR DESCRIPTION
Changelog-entry: Set private to false in .coffee files for the public device types
Signed-off-by: Florin Sarbu <florin@balena.io>