### PR TITLE
balena-up-board: replace references to resin-vars

### DIFF
--- a/layers/meta-balena-up-board/recipes-support/hostapp-update-hooks/files/999-resin-boot-cleaner
+++ b/layers/meta-balena-up-board/recipes-support/hostapp-update-hooks/files/999-resin-boot-cleaner
@@ -6,7 +6,7 @@
 
 set -o errexit
 
-. /usr/sbin/resin-vars
+. /usr/sbin/balena-config-vars
 
 DURING_UPDATE=${DURING_UPDATE:-0}
 


### PR DESCRIPTION
Replace all references to the 'resin-vars' script with 'balena-config-vars' as it has been renamed.

This PR needs to be merged when https://github.com/balena-os/meta-balena/pull/2142 has been merged.

Change-type: patch
Changelog-entry: balena-up-board: replace references to resin-vars
Signed-off-by: Mark Corbin <mark@balena.io>