### PR TITLE
up-board: balena-image: don't install grub modules

### DIFF
--- a/layers/meta-balena-up-board/recipes-core/images/balena-image.inc
+++ b/layers/meta-balena-up-board/recipes-core/images/balena-image.inc
@@ -12,7 +12,6 @@ NOHDD = "1"
 BALENA_IMAGE_BOOTLOADER = "grub-efi"
 BALENA_BOOT_PARTITION_FILES = " \
     grub-efi-bootx64.efi:/EFI/BOOT/bootx64.efi \
-    grub/x86_64-efi:/EFI/BOOT/x86_64-efi/ \
     grubenv:/EFI/BOOT/grubenv \
     "
 


### PR DESCRIPTION
The bootloader has all necessary modules built into the EFI image. Free
up some space by removing unnecessary GRUB modules.

This frees up ~3.5M.

Change-type: patch
Signed-off-by: Joseph Kogut <joseph@balena.io>