### PR TITLE
packagegroup-balena-connectivity: Remove extra wifi firmwares

### DIFF
--- a/layers/meta-balena-up-board/recipes-core/packagegroups/packagegroup-balena-connectivity.bbappend
+++ b/layers/meta-balena-up-board/recipes-core/packagegroups/packagegroup-balena-connectivity.bbappend
@@ -5,3 +5,50 @@ CONNECTIVITY_FIRMWARES_append = " linux-firmware-ath10k-qca6174"
 CONNECTIVITY_FIRMWARES_remove = "linux-firmware-wl12xx"
 CONNECTIVITY_FIRMWARES_remove = "linux-firmware-wl18xx"
 CONNECTIVITY_FIRMWARES_remove = "linux-firmware-wlcommon"
+
+# These were removed to allow for more rootfs space,
+# and were borrowed from balena-intel repository
+CONNECTIVITY_FIRMWARES_remove = " \
+    linux-firmware-bcm43455 \
+    linux-firmware-ibt-11-5 \
+    linux-firmware-ibt-12-16 \
+    linux-firmware-ibt-18-16-1 \
+    linux-firmware-ibt-hw-37-7 \
+    linux-firmware-ibt-hw-37-8 \
+    linux-firmware-iwlwifi-3168 \
+    linux-firmware-iwlwifi-9000 \
+    linux-firmware-iwlwifi-9260 \
+    linux-firmware-iwlwifi-qu-b0-hr-b0 \
+    linux-firmware-pcie8897 \
+    linux-firmware-rtl8723 \
+    linux-firmware-rtl8821 \
+    linux-firmware-rtl8723b-bt \
+    linux-firmware-ralink-nic \
+    linux-firmware-ath9k \
+    linux-firmware-ralink \
+    linux-firmware-rtl8192cu \
+    linux-firmware-rtl8192su \
+    linux-firmware-bcm43143 \
+    linux-firmware-iwlwifi-135-6 \
+    linux-firmware-iwlwifi-6000-4 \
+    linux-firmware-iwlwifi-6000g2a-6 \
+    linux-firmware-iwlwifi-6000g2b-6 \
+    linux-firmware-iwlwifi-6050-5 \
+    linux-firmware-iwlwifi-7260 \
+    linux-firmware-iwlwifi-7265 \
+    linux-firmware-iwlwifi-7265d \
+    linux-firmware-iwlwifi-8000c \
+    linux-firmware-iwlwifi-8265 \
+    linux-firmware-rtl8188eu \
+"
+
+# these are now just empty packages so let's remove them to avoid a build error
+CONNECTIVITY_FIRMWARES_remove = " \
+    linux-firmware-iwlwifi-3160-7 \
+    linux-firmware-iwlwifi-3160-8 \
+    linux-firmware-iwlwifi-3160-9 \
+    linux-firmware-iwlwifi-6000g2a-5 \
+    linux-firmware-iwlwifi-6000g2b-5 \
+    linux-firmware-iwlwifi-6050-4 \
+"
+


### PR DESCRIPTION
At this point the rootfs is about the max size and
can't accept the firmware update in meta-balena PR 2240:
    recipe balena-image-1.0-r0: task do_image_size_check: Failed
Until hostapp extensions work is done, let's make some space here
by removing some extra wifi firmware.

The list of packages that we remove here is borrowed from
the balena-intel repository.

If meta-balena PR 2240 isn't merged until hostext,
this PR can be reverted.

Changelog-entry: Remove extra wifi firmwares to shrink rootfs size
Signed-off-by: Alexandru Costache <alexandru@balena.io>