### PR TITLE
linux-intel: Include aufs module for devices that have been using aufs

### DIFF
--- a/layers/meta-balena-up-board/recipes-kernel/linux/linux-intel_%.bbappend
+++ b/layers/meta-balena-up-board/recipes-kernel/linux/linux-intel_%.bbappend
@@ -31,3 +31,10 @@ BALENA_CONFIGS_append = " acpi_configfs"
 BALENA_CONFIGS[acpi_configfs] = " \
 	CONFIG_ACPI_CONFIGFS=m \
 "
+
+# This device type has been using the aufs storage driver,
+# and during a HUP the storage in the inactive sysroot will
+# still be aufs, so we need to include the aufs driver going
+# further for it, as per the internal thread:
+# https://www.flowdock.com/app/rulemotion/resin-devices/threads/K2TQiSUfNDqBT5Ih6cciNI2d9QJ
+BALENA_CONFIGS_append_up-board = " aufs"


### PR DESCRIPTION
We now have automatic migration from aufs to overlayfs. For the hostOS
containers, the migration will be done only after another HUP so for
making things still work after the first HUP we need to keep including
the aufs kernel driver.

Changelog-entry: Include the aufs kernel module for devices that have been using aufs prior to the overlayfs migration
Signed-off-by: Florin Sarbu <florin@balena.io>