### PR TITLE
meta-balena-up-board:layer: Enable firmware compression

### DIFF
--- a/layers/meta-balena-up-board/conf/layer.conf
+++ b/layers/meta-balena-up-board/conf/layer.conf
@@ -10,3 +10,5 @@ BBFILE_PRIORITY_balena-up-board = "1337"
 ACPI_TABLES = "spidev1.0.asl spidev1.1.asl spidev2.0.asl spidev2.1.asl"
 
 SRCREV_machine_pn-linux-yocto_up-board = "2c5caa7e84311f2a0097974a697ac1f59030530e"
+
+FIRMWARE_COMPRESSION ?= "1"


### PR DESCRIPTION
We need to increase the available rootfs space

Changelog-entry: Enable firmware compression to increase available rootfs space
Signed-off-by: Florin Sarbu <florin@balena.io>