### PR TITLE
layer.conf: Re-add missing pinctrl drivers in the image

### DIFF
--- a/layers/meta-balena-up-board/conf/layer.conf
+++ b/layers/meta-balena-up-board/conf/layer.conf
@@ -16,3 +16,10 @@ SRCREV_machine_pn-linux-yocto_up-board = "2c5caa7e84311f2a0097974a697ac1f5903053
 FIRMWARE_COMPRESSION ?= "1"
 
 FULL_OPTIMIZATION = "-Os -pipe ${DEBUG_FLAGS}"
+
+MACHINE_ESSENTIAL_EXTRA_RDEPENDS += "kernel-module-upboard-cpld"
+MACHINE_ESSENTIAL_EXTRA_RDEPENDS += "kernel-module-upboard-ec"
+MACHINE_ESSENTIAL_EXTRA_RDEPENDS += "kernel-module-leds-upboard"
+MACHINE_ESSENTIAL_EXTRA_RDEPENDS += "kernel-module-pinctrl-upboard"
+MACHINE_ESSENTIAL_EXTRA_RDEPENDS += "kernel-module-pinctrl-upelement"
+MACHINE_ESSENTIAL_EXTRA_RDEPENDS += "kernel-module-spi-pxa2xx-up"


### PR DESCRIPTION
After upgrading to kirkstone the pinctrl driver is no longer present in the rootfs. See https://github.com/up-division/meta-up-board/issues/9 for details

Changelog-entry: Re-add pinctrl drivers that have been left out after the update to kirkstone