### PR TITLE
workflows/up-board.yml: Look for autokit worker in the bM instance

### DIFF
--- a/.github/workflows/up-board.yml
+++ b/.github/workflows/up-board.yml
@@ -53,7 +53,7 @@ jobs:
       test_matrix: >
         {
           "test_suite": ["os","cloud","hup"],
-          "environment": ["balena-cloud.com"],
+          "environment": ["bm.balena-dev.com"],
           "runs_on": [["ubuntu-latest"]]
         }
       # Allow manual workflow runs to force finalize without checking previous test runs


### PR DESCRIPTION
The bM instance seems to be more stable now so let's move this dt back to where it belongs.

Changelog-entry: Use the autokit worker from the bM instance for the up-board device type